### PR TITLE
Historic price API changes

### DIFF
--- a/src/protocol/beefy/connector/prices.ts
+++ b/src/protocol/beefy/connector/prices.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import * as Rx from "rxjs";
 import { SamplingPeriod } from "../../../types/sampling";
-import { BEEFY_DATA_URL } from "../../../utils/config";
+import { BEEFY_DATA_KEY, BEEFY_DATA_URL } from "../../../utils/config";
 import { rootLogger } from "../../../utils/logger";
 import { Range } from "../../../utils/range";
 import { rateLimit$ } from "../../../utils/rxjs/utils/rate-limit";
@@ -66,26 +66,25 @@ export async function fetchBeefyPrices(
   if (samplingPeriod !== "15min") {
     throw new Error(`Unsupported sampling period: ${samplingPeriod}`);
   }
-  const apiPeriod = samplingPeriod === "15min" ? "minute" : "minute";
   const startDate = options?.startDate || new Date(0);
   const endDate = options?.endDate || new Date(new Date().getTime() + 10000000);
 
   const params = {
-    name: oracleId,
-    period: apiPeriod,
+    oracle: oracleId,
     from: Math.floor(startDate.getTime() / 1000),
     to: Math.ceil(endDate.getTime() / 1000),
     limit: 1000000000,
+    key: BEEFY_DATA_KEY
   };
   logger.debug({ msg: "Fetching prices", data: { params } });
 
-  const res = await axios.get<{ ts: number; name: string; v: number }[]>(BEEFY_DATA_URL + "/price", { params });
+  const res = await axios.get<{ t: number; v: number }[]>(BEEFY_DATA_URL + "/api/v2/prices/range", { params });
 
   return res.data.map(
     (price) =>
       ({
-        datetime: new Date(price.ts),
-        oracleId: price.name,
+        datetime: new Date(price.t),
+        oracleId: oracleId,
         value: price.v,
       } as PriceSnapshot),
   );

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -35,6 +35,7 @@ export const DISABLE_PROGRAMMER_ERROR_DUMP = process.env.DISABLE_PROGRAMMER_ERRO
 export const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
 
 export const BEEFY_DATA_URL = process.env.BEEFY_DATA_URL || "https://data.beefy.finance";
+export const BEEFY_DATA_KEY = process.env.BEEFY_DATA_KEY || null;
 
 export const RPC_API_KEY_AURORA = process.env.RPC_API_KEY_AURORA || null;
 export const RPC_API_KEY_ANKR = process.env.RPC_API_KEY_ANKR || null;


### PR DESCRIPTION
We are upgrading the historic prices API, this PR prepares everything needed so we can keep consuming all historic prices as we currently are:
- new endpoint
- new response type
- add key to access the new endpoint since its access is limited to this project alone