### PR TITLE
Update data api rate limit param

### DIFF
--- a/src/protocol/beefy/connector/prices.ts
+++ b/src/protocol/beefy/connector/prices.ts
@@ -28,7 +28,7 @@ export function fetchBeefyDataPrices$<TObj, TErr extends ErrorEmitter<TObj>, TRe
 }): Rx.OperatorFunction<TObj, TRes> {
   return Rx.pipe(
     // be nice with beefy api plz
-    rateLimit$(300),
+    rateLimit$(1000),
 
     // now we fetch
     Rx.concatMap(async (item) => {
@@ -73,7 +73,7 @@ export async function fetchBeefyPrices(
     oracle: oracleId,
     from: Math.floor(startDate.getTime() / 1000),
     to: Math.ceil(endDate.getTime() / 1000),
-    key: BEEFY_DATA_KEY
+    key: BEEFY_DATA_KEY,
   };
   logger.debug({ msg: "Fetching prices", data: { params } });
 


### PR DESCRIPTION
data api has this rate limit config: https://github.com/beefyfinance/beefy-db-dev/blob/main/src/api/index.ts#L20

So we limit to 1 req/sec, that should be enough