### PR TITLE
Return complete timeline

### DIFF
--- a/src/api/service/protocol/beefy.ts
+++ b/src/api/service/protocol/beefy.ts
@@ -50,7 +50,6 @@ export class BeefyPortfolioService {
             from beefy_investor_timeline_cache_ts b
             join product p on p.product_id = b.product_id
             where b.investor_id = %L
-              and coalesce(p.product_data->>'dashboardEol')::text = 'false'
             order by product_key asc, datetime asc
         `,
         [investorId],


### PR DESCRIPTION
Remove tx restriction on old eol vaults, UI needs whole history to show pnl numbers even of eol vaults for dashboard
