### PR TITLE
Change API endpoint to use .finance

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -168,8 +168,8 @@ services:
       TIMESCALEDB_URL: postgres://api_ro:api_ro@timescaledb:5432/beefy
       API_LISTEN: "::" # listen on all interfaces inside the container
       WORK_CMD: "./dist/src/api/server.js"
-      LETSENCRYPT_HOST: databarn.beefy.com
-      VIRTUAL_HOST: databarn.beefy.com
+      LETSENCRYPT_HOST: databarn.beefy.finance
+      VIRTUAL_HOST: databarn.beefy.finance
       VIRTUAL_PORT: 8080
       TRUST_DOWNSTREAM_PROXY: true
     logging:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -168,8 +168,8 @@ services:
       TIMESCALEDB_URL: postgres://api_ro:api_ro@timescaledb:5432/beefy
       API_LISTEN: "::" # listen on all interfaces inside the container
       WORK_CMD: "./dist/src/api/server.js"
-      LETSENCRYPT_HOST: databarn.beefy.finance
-      VIRTUAL_HOST: databarn.beefy.finance
+      LETSENCRYPT_HOST: databarn.beefy.com,databarn.beefy.finance
+      VIRTUAL_HOST: databarn.beefy.com,databarn.beefy.finance
       VIRTUAL_PORT: 8080
       TRUST_DOWNSTREAM_PROXY: true
     logging:


### PR DESCRIPTION
Change .com -> .finance for api endpoint since beefy.com is still blacklisted in some countries (related to previous url use)